### PR TITLE
Use relative path for Python3 under Windows

### DIFF
--- a/KiBuzzard/__init__.py
+++ b/KiBuzzard/__init__.py
@@ -83,7 +83,7 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
             if sys.platform.startswith('linux'):
                 process = subprocess.Popen(['python', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             else:
-                process = subprocess.Popen(['C:\\Python38\\python.exe', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+                process = subprocess.Popen(['python3.exe', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             stdout, stderr = process.communicate()
             if stderr:
                 wx.MessageBox(stderr, 'Error', wx.OK | wx.ICON_ERROR)


### PR DESCRIPTION
Python installed from Microsoft Store is not installed into the same directory as Python from official distribution. However, both should be in `PATH`, so it's better to use relative path. Also, `python3.exe` must be used, because `python.exe` is 2.7 bundled with KiCad (at least with kicad-r20439.02f91c52a0-x86_64).

```
PS C:\Users\nephirus> get-command python3 |select-object Source

Source
------
C:\Users\nephirus\AppData\Local\Microsoft\WindowsApps\python3.exe
```