### PR TITLE
Macos integration

### DIFF
--- a/KiBuzzard/__init__.py
+++ b/KiBuzzard/__init__.py
@@ -80,8 +80,8 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
 
             # Execute Buzzard
             process = None
-            if sys.platform.startswith('linux'):
-                process = subprocess.Popen(['python', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if sys.platform.startswith('linux') or sys.platform == 'darwin':
+                process = subprocess.Popen(['python3', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             else:
                 process = subprocess.Popen(['C:\\Python38\\python.exe', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             stdout, stderr = process.communicate()
@@ -93,10 +93,12 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
             if len(error_line) > 0:
                 wx.MessageBox(error_line[0], 'Error', wx.OK | wx.ICON_ERROR)
 
-            else:        
+            else:
                 # Copy footprint into clipboard
                 if sys.platform.startswith('linux'):
                     clip_args = ['xclip', '-sel', 'clip', '-noutf8']
+                elif sys.platform == 'darwin':
+                    clip_args = ['pbcopy']
                 else:
                     clip_args = ['clip.exe']
 
@@ -112,7 +114,7 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
                 self._pcbnew_frame.Raise()
                 wx.Yield()
                 keyinput = wx.UIActionSimulator()
-                keyinput.Char(ord("V"), wx.MOD_CONTROL)    
+                keyinput.Char(ord("V"), wx.MOD_CONTROL)
         finally:
             self.config.Flush()
             dlg.Destroy()


### PR DESCRIPTION
Adds check for `darwin` platform, and uses appropriate clipboard command (`pbcopy`)

<img width="1392" alt="Screen Shot 2021-01-27 at 1 49 40 AM" src="https://user-images.githubusercontent.com/428908/105973717-ed946c00-6041-11eb-8efd-d54f30fd7801.png">
 
Note: On KiCAD 5.99 nightly builds for macOS, users must specify the `PYTHONPATH` environment variable with the system path to python3 site-packages, apparently.

Also, Users must grant "Accessibility" permissions in the macOS Security & Privacy settings
<img width="780" alt="Screen Shot 2021-01-27 at 12 45 57 AM" src="https://user-images.githubusercontent.com/428908/105973967-3815e880-6042-11eb-83ac-56e113eecced.png">
