### PR TITLE
using path instead of C:\Python38

### DIFF
--- a/KiBuzzard/__init__.py
+++ b/KiBuzzard/__init__.py
@@ -85,7 +85,12 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
             if sys.platform.startswith('linux') or sys.platform == 'darwin':
                 process = subprocess.Popen(['python3', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             else:
-                process = subprocess.Popen(['C:\\Python38\\python.exe', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+                env_without_kicad = os.environ.copy()
+                path_without_kicad = env_without_kicad["PATH"].split(';')
+                path_without_kicad = [x for x in path_without_kicad if 'KiCad' not in x]
+                path_without_kicad = ';'.join(path_without_kicad)
+                env_without_kicad["PATH"] = path_without_kicad
+                process = subprocess.Popen(['python', buzzard_script] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, env=env_without_kicad) # Use PATH instead of C:\\Python38\\python.exe
             stdout, stderr = process.communicate()
             if stderr:
                 wx.MessageBox(stderr, 'Error', wx.OK | wx.ICON_ERROR)


### PR DESCRIPTION
Fix for #15 on Windows.

This is probably not be the best way to do it, but it works. Basically, it grabs the current PATH, deletes entries that contain `KiCad` and then executes the script using that environment. This way it finds the default python installation on the system PATH, and skips the python 2.7 that comes with KiCad.