### PR TITLE
fix hardcoded python3 path on Windows + output mode for Buzzard + fix the double escape issue

### DIFF
--- a/KiBuzzard/__init__.py
+++ b/KiBuzzard/__init__.py
@@ -132,8 +132,6 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
 
             str = str + ' -stdout -o ki' + ('5' if '5.1' in pcbnew.GetBuildVersion() else '')
             args = [a.strip('"') for a in re.findall('".+?"|\S+', str)]
-            if sys.platform.startswith('win'):
-                args = [re.sub('([<>])', r'^\1', a) for a in args] # escape '<' or '>' with a caret, '^<'
 
             # Execute Buzzard
             process = None

--- a/KiBuzzard/__init__.py
+++ b/KiBuzzard/__init__.py
@@ -130,7 +130,7 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
         def run_buzzard(str):
             import re
 
-            str = str + ' -o ki -stdout'
+            str = str + ' -stdout -o ki' + ('5' if '5.1' in pcbnew.GetBuildVersion() else '')
             args = [a.strip('"') for a in re.findall('".+?"|\S+', str)]
             if sys.platform.startswith('win'):
                 args = [re.sub('([<>])', r'^\1', a) for a in args] # escape '<' or '>' with a caret, '^<'


### PR DESCRIPTION
While @gregdavill is working on integrating Buzzard functionality directly into KiBuzzard until that is done, this should fix the issue with the hardcoded python3 path on Windows.

It also correctly sets the Buzzard output mode based on Kicad version and removes the escaping on windows, as its not needed.

@arturo182, @Plasmabot1, @Nephirus - I know you guys use Windows, can you help me test this on other machines/installations ?