### PR TITLE
Fix wx macOS incompatibility

### DIFF
--- a/KiBuzzard/dialog/dialog.py
+++ b/KiBuzzard/dialog/dialog.py
@@ -46,7 +46,7 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         self.m_sdbSizerCancel.Bind(wx.EVT_BUTTON, self.Cancel)
 
         self.timer = wx.Timer(self, 0)
-        self.timer.StartOnce(milliseconds=250)
+        self.timer.Start(milliseconds=250, oneShot=True)
 
     def Cancel(self, e):
         self.timer.Stop()
@@ -73,7 +73,7 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
             self.sourceText = self.CurrentSettings()
             self.ReGeneratePreview()
 
-        self.timer.StartOnce(milliseconds=250)
+        self.timer.Start(milliseconds=250, oneShot=True)
         event.Skip()
 
     def ReGenerateFlag(self, e):

--- a/KiBuzzard/dialog/dialog_text_base.py
+++ b/KiBuzzard/dialog/dialog_text_base.py
@@ -114,8 +114,6 @@ class DIALOG_TEXT_BASE ( DialogShim ):
         self.m_SizeYLabel = wx.StaticText( self, wx.ID_ANY, _(u"Height:"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_SizeYLabel.Wrap( -1 )
 
-        self.m_SizeYLabel.SetToolTip( _(u"Text height") )
-
         fgSizerSetup.Add( self.m_SizeYLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT|wx.LEFT, 5 )
 
         self.m_SizeYCtrl = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_PROCESS_ENTER )
@@ -139,8 +137,6 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         self.m_ThicknessLabel = wx.StaticText( self, wx.ID_ANY, _(u"Thickness:"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_ThicknessLabel.Wrap( -1 )
-
-        self.m_ThicknessLabel.SetToolTip( _(u"Text thickness") )
 
         fgSizerSetup.Add( self.m_ThicknessLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT|wx.LEFT, 5 )
 

--- a/text_dialog.fbp
+++ b/text_dialog.fbp
@@ -660,7 +660,7 @@
                                 <property name="style"></property>
                                 <property name="subclass"></property>
                                 <property name="toolbar_pane">0</property>
-                                <property name="tooltip">Text height</property>
+                                <property name="tooltip"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
@@ -972,7 +972,7 @@
                                 <property name="style"></property>
                                 <property name="subclass"></property>
                                 <property name="toolbar_pane">0</property>
-                                <property name="tooltip">Text thickness</property>
+                                <property name="tooltip"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>


### PR DESCRIPTION
Removed the remaining tool tips. 
Also I had to modify the `StartOnce` call to the `wx.Timer`.
For some reason it did not like this one.
Thankfully `self.timer.Start(milliseconds=250, oneShot=True)` does the same thing. 

This fixes #27

I am successfully using KiBuzzard now on macOS with KiCad Nightly 5.99 🚀

![Screenshot 2021-04-11 at 12 32 47](https://user-images.githubusercontent.com/3868463/114300844-5d06ed00-9ac2-11eb-9ae7-5b385effc1b7.png)
