### PR TITLE
Improve logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.pyc
-
 config.ini
+kibuzzard.log
+error.log

--- a/KiBuzzard/__init__.py
+++ b/KiBuzzard/__init__.py
@@ -43,9 +43,16 @@ def check_for_bom_button():
             top_tb.Bind(wx.EVT_TOOL, callback, id=button_wx_item_id)
             top_tb.Realize()
 
-from .plugin import KiBuzzardPlugin
-plugin = KiBuzzardPlugin()
-plugin.register()
+try:
+    from .plugin import KiBuzzardPlugin
+    plugin = KiBuzzardPlugin()
+    plugin.register()
+except Exception as e:
+    import os
+    plugin_dir = os.path.dirname(os.path.realpath(__file__))
+    log_file = os.path.join(plugin_dir, 'error.log')
+    with open(log_file, 'w') as f:
+        f.write(repr(e))
 
 # Add a button the hacky way if plugin button is not supported
 # in pcbnew, unless this is linux.


### PR DESCRIPTION
To be able to track down issues quicker and also improve the overall dev experience I figured it would be nice to have a little more logging capabilities.

I've added a basic error log that kicks in when there is an error upon plugin registration.
In case there is an exception it will create a `error.log` file within the KiBuzzard subdir containing the exception.

But the bigger improvement is that there is now a basic configuration for python's `logging` module.
You have two ways of logging stuff.

```python
# In plugin.py there already is a self.logger object so you can:
self.logger.info("This is from the plugin.py file! It should log even before the dialog was opened.")

# In every other file you can easily pull in the logger via:
import logging
logger = logging.getLogger(__name__)
logger.info("This is from dialog.py and should log as soon as you hit Cancel!")
```

All logs (also regular stderr or stdout) will be written to a `kibuzard.log` file in the root plugin directory.

This is the `kibuzzard.log` file you get with the above examples:
```
04-12 13:43:11 KiBuzzard.KiBuzzard.plugin 25:This is from the plugin.py file! It should log even before the dialog was opened.
04-12 13:43:19 KiBuzzard.KiBuzzard.dialog.dialog 56:This is from dialog.py and should log as soon as you hit Cancel!
```

The file is not bloated as it gets reinitialized every time the plugin loads.