### PR TITLE
Modified scaling mechanism to provide accurate dimensioning

### DIFF
--- a/KiBuzzard/buzzard/buzzard.py
+++ b/KiBuzzard/buzzard/buzzard.py
@@ -24,11 +24,12 @@ class Buzzard():
         self.fontName = 'FredokaOne'
         self.layer = 'F.Cu'
         self.verbose = True
-        self.scaleFactor = 0.04
+        self.scaleFactor = 96/4
         self.subSampling = 0.1
         self.traceWidth = 0.1
         self.padding = Padding()
         self.width = 0
+        self.minHeight = 0.1
         self.alignment = ''
         self.leftCap = ''                # Used to store cap shape for left side of tag
         self.rightCap = ''               # Used to store cap shape for right side of tag-
@@ -80,8 +81,6 @@ class Buzzard():
     
         # bounds check padding
         padding = self.padding
-        for attr in ['left', 'right', 'top', 'bottom']:
-            if getattr(padding,attr) <= 0: setattr(padding, attr, 0.001)
 
         bbox = t.bbox()
         height = bbox[1].y - bbox[0].y
@@ -138,7 +137,7 @@ class Buzzard():
                 pstr += "h {} l {},{} l {},{} h {}".format(height/3, height/-3, height/-2, height/3, height/-2, height/-3)
             
             pstr += "h {} ".format(-padding.right)
-            pstr += "h {} z".format(-1*width)
+            pstr += "h {} z".format(-width)
 
             p = svg.Path()
             p.parse(pstr)
@@ -169,7 +168,7 @@ class Svg2ModExportLatestCustom( Svg2ModExportLatest ):
         file_name = None,
         center = True,
         scale_factor = 1.0,
-        precision = 20.0,
+        precision = 1.0,
         use_mm = True,
         dpi = DEFAULT_DPI,
         params = None

--- a/KiBuzzard/dialog/dialog.py
+++ b/KiBuzzard/dialog/dialog.py
@@ -10,7 +10,7 @@ import json
 
 from . import dialog_text_base
 
-def ParseFloat(InputString, DefaultValue=0.0):
+def ParseFloat(InputString, DefaultValue=0.001):
     value = DefaultValue
     if InputString != "":
         try:
@@ -28,10 +28,10 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         'LayerComboBox': 'F.Cu',
         'CapLeftChoice': '[',
         'CapRightChoice': ']',
-        'PaddingTopCtrl': '5',
-        'PaddingLeftCtrl': '5',
-        'PaddingRightCtrl': '5',
-        'PaddingBottomCtrl': '5',
+        'PaddingTopCtrl': '3.75',
+        'PaddingLeftCtrl': '3.75',
+        'PaddingRightCtrl': '3.75',
+        'PaddingBottomCtrl': '3.75',
         'WidthCtrl': None,
         'AlignmentChoice': 'Center'
     }
@@ -56,11 +56,9 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         self._layer_choices = layer_choices = ["F.Cu", "F.Paste", "F.SilkS", "F.Mask", "F.Cu/F.Mask"]
         self.m_LayerComboBox.AppendItems(layer_choices)
         self.m_LayerComboBox.SetSelection(0)
-
         self.m_HeightUnits.SetLabel("mm")
         self.m_WidthUnits.SetLabel("mm")
-        self.m_PaddingUnits.SetLabel("")
-        
+        self.m_PaddingUnits.SetLabel("FUnits")
 
         best_size = self.BestSize
         # hack for some gtk themes that incorrectly calculate best size
@@ -74,9 +72,7 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         self.label_params = {}
         self.updateFootprint = None
 
-
         self.loadConfig()
-
 
         self.buzzard = buzzard
 
@@ -183,10 +179,8 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         while self.label_params != self.CurrentSettings():
             self.label_params.update(self.CurrentSettings())
             self.ReGeneratePreview()
-
         self.timer.Start(milliseconds=250, oneShot=True)
         event.Skip()
-
     
     def OnCharHook( self, event ):
         if (event.GetKeyCode() == wx.WXK_RETURN) & (event.ShiftDown() | event.ControlDown()):
@@ -199,39 +193,81 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         self.label_params = {}
 
     def ReGeneratePreview(self, e=None):
-        
         self.polys = []
+        
         self.buzzard.fontName = self.m_FontComboBox.GetValue()
 
-        # Validate scale factor
-        scale = ParseFloat(self.m_HeightCtrl.GetValue(), 1.0)
-
-        if scale == 0:
-            if self.buzzard.scaleFactor != 0:
-                scale = self.buzzard.scaleFactor * 2.0
-            else:
-                scale = 0.01 # avoid a /0, when changing the scale.
-
-        self.buzzard.scaleFactor = scale * 0.5
-
-        DefaultPadding = 7.75 * 4 * 0.25 * (1/scale)
-        self.buzzard.padding.top = ParseFloat(self.m_PaddingTopCtrl.GetValue(), DefaultPadding) * 0.5
-        self.buzzard.padding.left = ParseFloat(self.m_PaddingLeftCtrl.GetValue(), DefaultPadding) * 0.5
-        self.buzzard.padding.right = ParseFloat(self.m_PaddingRightCtrl.GetValue(), DefaultPadding) * 0.5
-        self.buzzard.padding.bottom = ParseFloat(self.m_PaddingBottomCtrl.GetValue(), DefaultPadding) * 0.5
-
+        requestedHeight = ParseFloat(self.m_HeightCtrl.GetValue())
+        requestedWidth = ParseFloat(self.m_WidthCtrl.GetValue())
+        
+        if requestedHeight < self.buzzard.minHeight:
+            requestedHeight = self.buzzard.minHeight
+            self.m_HeightCtrl.SetValue(self.buzzard.minHeight)
+        
+        self.buzzard.padding.top = ParseFloat(self.m_PaddingTopCtrl.GetValue())
+        self.buzzard.padding.left = ParseFloat(self.m_PaddingLeftCtrl.GetValue())
+        self.buzzard.padding.right = ParseFloat(self.m_PaddingRightCtrl.GetValue())
+        self.buzzard.padding.bottom = ParseFloat(self.m_PaddingBottomCtrl.GetValue())
+        
+        #this was originally in buzzard.py but have moved it here in order to accomodate
+        #realtime updates of padding
+        for attr in ['left', 'right', 'top', 'bottom']:
+            if getattr(self.buzzard.padding,attr) <= 0: setattr(self.buzzard.padding, attr, 0.001) 
+ 
+        #do the realtime update
+        for attr, ctrl in [('left','m_PaddingLeftCtrl'), ('right','m_PaddingRightCtrl'), ('top','m_PaddingTopCtrl'), ('bottom','m_PaddingBottomCtrl')]:            
+            getattr(self, ctrl).SetValue(getattr(self.buzzard.padding, attr,3))
+  
         self.buzzard.layer = self.m_LayerComboBox.GetValue()
-        self.buzzard.width = ParseFloat(self.m_WidthCtrl.GetValue(), 0.0) *  7.55625 * (1/scale)
+        self.buzzard.width = ParseFloat(self.m_WidthCtrl.GetValue(), 0.0)
 
         self.buzzard.alignment = self.m_AlignmentChoice.GetStringSelection()
+
+        #initial render with no caps to determine text-only bounding-box sizing for scaling
+        if self.m_MultiLineText.GetValue():
+            self.buzzard.leftCap = 'square'
+            self.buzzard.rightCap = 'square'
+            t=self.buzzard.renderLabel(self.m_MultiLineText.GetValue())
+        
+            textWidth=round(t.bbox()[1].x-t.bbox()[0].x,3)
+            textHeight=round(t.bbox()[1].y-t.bbox()[0].y,3)
+            self.buzzard.scaleFactor=(96/25.4)*((requestedHeight-(self.buzzard.padding.top-self.buzzard.padding.bottom))/textHeight)
+            rawScaleFactor=(self.buzzard.scaleFactor/(96/25.4))
+
+            scaledTextWidth=textWidth*rawScaleFactor            
 
         styles = {'':'', '(':'round', '[':'square', '<':'pointer', '/':'fslash', '\\':'bslash', '>':'flagtail'}
         self.buzzard.leftCap = styles[self.m_CapLeftChoice.GetStringSelection()]
 
         styles = {'':'', ')':'round', ']':'square', '>':'pointer', '/':'fslash', '\\':'bslash', '<':'flagtail'}
         self.buzzard.rightCap = styles[self.m_CapRightChoice.GetStringSelection()]
-        self.error = None
+        
+        #render again with the caps in order to calculate width modifiers
+        if self.m_MultiLineText.GetValue():
+            t=self.buzzard.renderLabel(self.m_MultiLineText.GetValue())
+            
+            labelWidth=round((t.bbox()[1].x-t.bbox()[0].x),3)
+            labelHeight=round(t.bbox()[1].y-t.bbox()[0].y,3)
+            
+            scaledLabelWidth=labelWidth*rawScaleFactor
+            scaledLabelHeight=labelHeight*rawScaleFactor
+            deltaWidth=scaledLabelWidth-scaledTextWidth
+            
+            #in order to make our item width match the requested item 
+            #width we have to adjust our our width by the requested size
+            #and the delta of the caps
+            self.buzzard.width = ParseFloat((requestedWidth-deltaWidth)/rawScaleFactor, 0.000)
+            #if (self.buzzard.leftCap != '') & (self.buzzard.rightCap != ''): #causes an error due to the fact that the bounding box is created 
+            if self.m_HeightCtrl.GetValue() < requestedHeight:
+                self.m_HeightCtrl.SetValue(scaledLabelHeight) 
+            #needed for realtime update of size since we can not set the width smaller than the bounding box created
+            #for that particular height of character.
+            #character height drives the scaling factor and thus is applied first
+            if requestedWidth<scaledLabelWidth:
+                self.m_WidthCtrl.SetValue(scaledLabelWidth)
 
+            self.error = None
+        
         if len(self.m_MultiLineText.GetValue()) == 0:
             self.RePaint()
             return
@@ -245,7 +281,7 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
             import traceback
             traceback.print_exc()
 
-        self.RePaint()
+        self.RePaint()        
 
     def RePaint(self, e=None):
         self.Layout()

--- a/KiBuzzard/dialog/dialog_text_base.py
+++ b/KiBuzzard/dialog/dialog_text_base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ###########################################################################
-## Python code generated with wxFormBuilder (version 3.10.1-0-g8feb16b3)
+## Python code generated with wxFormBuilder (version 3.10.1-88b0f50)
 ## http://www.wxformbuilder.org/
 ##
 ## PLEASE DO *NOT* EDIT THIS FILE!
@@ -116,8 +116,8 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         fgSizerSetup.Add( self.m_HeightLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT|wx.LEFT, 5 )
 
-        self.m_HeightCtrl = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_PROCESS_ENTER )
-        self.m_HeightCtrl.SetMaxLength( 0 )
+        self.m_HeightCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 128, 0, 0.25 )
+        self.m_HeightCtrl.SetDigits( 3 )
         fgSizerSetup.Add( self.m_HeightCtrl, 0, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
 
         self.m_HeightUnits = wx.StaticText( self, wx.ID_ANY, _(u"unit"), wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -140,8 +140,8 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         fgSizerSetup.Add( self.m_WidthLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.LEFT|wx.RIGHT, 5 )
 
-        self.m_WidthCtrl = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_PROCESS_ENTER )
-        self.m_WidthCtrl.SetMaxLength( 0 )
+        self.m_WidthCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 128, 0, 0.25 )
+        self.m_WidthCtrl.SetDigits( 3 )
         fgSizerSetup.Add( self.m_WidthCtrl, 0, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
 
         self.m_WidthUnits = wx.StaticText( self, wx.ID_ANY, _(u"unit"), wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -199,6 +199,21 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         fgSizerPadding.Add( self.m_PaddingLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.LEFT|wx.RIGHT, 5 )
 
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
         self.m_PaddingTopLabel = wx.StaticText( self, wx.ID_ANY, _(u"Top"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_PaddingTopLabel.Wrap( -1 )
 
@@ -225,34 +240,29 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
-        self.m_PaddingTopCtrl = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_PROCESS_ENTER )
-        self.m_PaddingTopCtrl.SetMaxLength( 0 )
-        self.m_PaddingTopCtrl.SetMinSize( wx.Size( 64,-1 ) )
+        self.m_PaddingTopCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
+        self.m_PaddingTopCtrl.SetDigits( 3 )
+        fgSizerPadding.Add( self.m_PaddingTopCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
-        fgSizerPadding.Add( self.m_PaddingTopCtrl, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
+        self.m_PaddingLeftCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
+        self.m_PaddingLeftCtrl.SetDigits( 3 )
+        fgSizerPadding.Add( self.m_PaddingLeftCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
-        self.m_PaddingLeftCtrl = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_PROCESS_ENTER )
-        self.m_PaddingLeftCtrl.SetMaxLength( 0 )
-        self.m_PaddingLeftCtrl.SetMinSize( wx.Size( 64,-1 ) )
+        self.m_PaddingRightCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
+        self.m_PaddingRightCtrl.SetDigits( 3 )
+        fgSizerPadding.Add( self.m_PaddingRightCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
-        fgSizerPadding.Add( self.m_PaddingLeftCtrl, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
-
-        self.m_PaddingRightCtrl = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_PROCESS_ENTER )
-        self.m_PaddingRightCtrl.SetMaxLength( 0 )
-        self.m_PaddingRightCtrl.SetMinSize( wx.Size( 64,-1 ) )
-
-        fgSizerPadding.Add( self.m_PaddingRightCtrl, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
-
-        self.m_PaddingBottomCtrl = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.TE_PROCESS_ENTER )
-        self.m_PaddingBottomCtrl.SetMaxLength( 0 )
-        self.m_PaddingBottomCtrl.SetMinSize( wx.Size( 64,-1 ) )
-
-        fgSizerPadding.Add( self.m_PaddingBottomCtrl, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
+        self.m_PaddingBottomCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
+        self.m_PaddingBottomCtrl.SetDigits( 3 )
+        fgSizerPadding.Add( self.m_PaddingBottomCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
         self.m_PaddingUnits = wx.StaticText( self, wx.ID_ANY, _(u"unit"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_PaddingUnits.Wrap( -1 )
 
         fgSizerPadding.Add( self.m_PaddingUnits, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT|wx.LEFT, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
 
         bMainSizer.Add( fgSizerPadding, 0, wx.EXPAND|wx.LEFT|wx.RIGHT, 10 )
@@ -287,12 +297,6 @@ class DIALOG_TEXT_BASE ( DialogShim ):
         # Connect Events
         self.Bind( wx.EVT_INIT_DIALOG, self.OnInitDlg )
         self.m_MultiLineText.Bind( wx.EVT_CHAR_HOOK, self.OnCharHook )
-        self.m_HeightCtrl.Bind( wx.EVT_TEXT_ENTER, self.OnOkClick )
-        self.m_WidthCtrl.Bind( wx.EVT_TEXT_ENTER, self.OnOkClick )
-        self.m_PaddingTopCtrl.Bind( wx.EVT_TEXT_ENTER, self.OnOkClick )
-        self.m_PaddingLeftCtrl.Bind( wx.EVT_TEXT_ENTER, self.OnOkClick )
-        self.m_PaddingRightCtrl.Bind( wx.EVT_TEXT_ENTER, self.OnOkClick )
-        self.m_PaddingBottomCtrl.Bind( wx.EVT_TEXT_ENTER, self.OnOkClick )
         self.m_sdbSizerOK.Bind( wx.EVT_BUTTON, self.OnOkClick )
 
     def __del__( self ):
@@ -308,11 +312,5 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
     def OnOkClick( self, event ):
         pass
-
-
-
-
-
-
 
 

--- a/text_dialog.fbp
+++ b/text_dialog.fbp
@@ -669,11 +669,11 @@
                                 <property name="wrap">-1</property>
                             </object>
                         </object>
-                        <object class="sizeritem" expanded="0">
+                        <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
                             <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
                             <property name="proportion">0</property>
-                            <object class="wxTextCtrl" expanded="0">
+                            <object class="wxSpinCtrlDouble" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -691,6 +691,7 @@
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>
                                 <property name="default_pane">0</property>
+                                <property name="digits">3</property>
                                 <property name="dock">Dock</property>
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
@@ -701,10 +702,13 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
+                                <property name="inc">0.25</property>
+                                <property name="initial">0</property>
+                                <property name="max">128</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
                                 <property name="maximum_size"></property>
-                                <property name="maxlength">0</property>
+                                <property name="min">0</property>
                                 <property name="min_size"></property>
                                 <property name="minimize_button">0</property>
                                 <property name="minimum_size"></property>
@@ -719,19 +723,14 @@
                                 <property name="resize">Resizable</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
-                                <property name="style">wxTE_PROCESS_ENTER</property>
+                                <property name="style">wxSP_ARROW_KEYS</property>
                                 <property name="subclass">; ; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>
-                                <property name="validator_data_type"></property>
-                                <property name="validator_style">wxFILTER_NONE</property>
-                                <property name="validator_type">wxDefaultValidator</property>
-                                <property name="validator_variable"></property>
                                 <property name="value"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
-                                <event name="OnTextEnter">OnOkClick</event>
                             </object>
                         </object>
                         <object class="sizeritem" expanded="0">
@@ -985,7 +984,7 @@
                             <property name="border">5</property>
                             <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
                             <property name="proportion">0</property>
-                            <object class="wxTextCtrl" expanded="1">
+                            <object class="wxSpinCtrlDouble" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -1003,6 +1002,7 @@
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>
                                 <property name="default_pane">0</property>
+                                <property name="digits">3</property>
                                 <property name="dock">Dock</property>
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
@@ -1013,10 +1013,13 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
+                                <property name="inc">0.25</property>
+                                <property name="initial">0</property>
+                                <property name="max">128</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
                                 <property name="maximum_size"></property>
-                                <property name="maxlength">0</property>
+                                <property name="min">0</property>
                                 <property name="min_size"></property>
                                 <property name="minimize_button">0</property>
                                 <property name="minimum_size"></property>
@@ -1031,19 +1034,14 @@
                                 <property name="resize">Resizable</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
-                                <property name="style">wxTE_PROCESS_ENTER</property>
+                                <property name="style">wxSP_ARROW_KEYS</property>
                                 <property name="subclass">; ; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>
-                                <property name="validator_data_type"></property>
-                                <property name="validator_style">wxFILTER_NONE</property>
-                                <property name="validator_type">wxDefaultValidator</property>
-                                <property name="validator_variable"></property>
                                 <property name="value"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
-                                <event name="OnTextEnter">OnOkClick</event>
                             </object>
                         </object>
                         <object class="sizeritem" expanded="1">
@@ -1537,6 +1535,56 @@
                         </object>
                         <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
+                            <property name="flag">wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="spacer" expanded="1">
+                                <property name="height">0</property>
+                                <property name="permission">protected</property>
+                                <property name="width">0</property>
+                            </object>
+                        </object>
+                        <object class="sizeritem" expanded="1">
+                            <property name="border">5</property>
+                            <property name="flag">wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="spacer" expanded="1">
+                                <property name="height">0</property>
+                                <property name="permission">protected</property>
+                                <property name="width">0</property>
+                            </object>
+                        </object>
+                        <object class="sizeritem" expanded="1">
+                            <property name="border">5</property>
+                            <property name="flag">wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="spacer" expanded="1">
+                                <property name="height">0</property>
+                                <property name="permission">protected</property>
+                                <property name="width">0</property>
+                            </object>
+                        </object>
+                        <object class="sizeritem" expanded="1">
+                            <property name="border">5</property>
+                            <property name="flag">wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="spacer" expanded="1">
+                                <property name="height">0</property>
+                                <property name="permission">protected</property>
+                                <property name="width">0</property>
+                            </object>
+                        </object>
+                        <object class="sizeritem" expanded="1">
+                            <property name="border">5</property>
+                            <property name="flag">wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="spacer" expanded="1">
+                                <property name="height">0</property>
+                                <property name="permission">protected</property>
+                                <property name="width">0</property>
+                            </object>
+                        </object>
+                        <object class="sizeritem" expanded="1">
+                            <property name="border">5</property>
                             <property name="flag">wxALIGN_CENTER</property>
                             <property name="proportion">1</property>
                             <object class="wxStaticText" expanded="1">
@@ -1799,11 +1847,11 @@
                                 <property name="width">0</property>
                             </object>
                         </object>
-                        <object class="sizeritem" expanded="0">
+                        <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
-                            <property name="proportion">1</property>
-                            <object class="wxTextCtrl" expanded="0">
+                            <property name="flag">wxALIGN_CENTER_VERTICAL</property>
+                            <property name="proportion">0</property>
+                            <object class="wxSpinCtrlDouble" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -1821,6 +1869,7 @@
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>
                                 <property name="default_pane">0</property>
+                                <property name="digits">3</property>
                                 <property name="dock">Dock</property>
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
@@ -1831,13 +1880,16 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
+                                <property name="inc">1</property>
+                                <property name="initial">0</property>
+                                <property name="max">100</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
                                 <property name="maximum_size"></property>
-                                <property name="maxlength">0</property>
-                                <property name="min_size">-1,-1</property>
+                                <property name="min">0</property>
+                                <property name="min_size"></property>
                                 <property name="minimize_button">0</property>
-                                <property name="minimum_size">64,-1</property>
+                                <property name="minimum_size">-1,-1</property>
                                 <property name="moveable">1</property>
                                 <property name="name">m_PaddingTopCtrl</property>
                                 <property name="pane_border">1</property>
@@ -1849,26 +1901,21 @@
                                 <property name="resize">Resizable</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
-                                <property name="style">wxTE_PROCESS_ENTER</property>
+                                <property name="style">wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</property>
                                 <property name="subclass">; ; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>
-                                <property name="validator_data_type"></property>
-                                <property name="validator_style">wxFILTER_NONE</property>
-                                <property name="validator_type">wxDefaultValidator</property>
-                                <property name="validator_variable"></property>
                                 <property name="value"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
-                                <event name="OnTextEnter">OnOkClick</event>
                             </object>
                         </object>
                         <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
-                            <property name="proportion">1</property>
-                            <object class="wxTextCtrl" expanded="1">
+                            <property name="flag">wxALIGN_CENTER_VERTICAL</property>
+                            <property name="proportion">0</property>
+                            <object class="wxSpinCtrlDouble" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -1886,6 +1933,7 @@
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>
                                 <property name="default_pane">0</property>
+                                <property name="digits">3</property>
                                 <property name="dock">Dock</property>
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
@@ -1896,13 +1944,16 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
+                                <property name="inc">1</property>
+                                <property name="initial">0</property>
+                                <property name="max">100</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
                                 <property name="maximum_size"></property>
-                                <property name="maxlength">0</property>
-                                <property name="min_size"></property>
+                                <property name="min">0</property>
+                                <property name="min_size">-1,-1</property>
                                 <property name="minimize_button">0</property>
-                                <property name="minimum_size">64,-1</property>
+                                <property name="minimum_size">-1,-1</property>
                                 <property name="moveable">1</property>
                                 <property name="name">m_PaddingLeftCtrl</property>
                                 <property name="pane_border">1</property>
@@ -1914,26 +1965,21 @@
                                 <property name="resize">Resizable</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
-                                <property name="style">wxTE_PROCESS_ENTER</property>
+                                <property name="style">wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</property>
                                 <property name="subclass">; ; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>
-                                <property name="validator_data_type"></property>
-                                <property name="validator_style">wxFILTER_NONE</property>
-                                <property name="validator_type">wxDefaultValidator</property>
-                                <property name="validator_variable"></property>
                                 <property name="value"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
-                                <event name="OnTextEnter">OnOkClick</event>
                             </object>
                         </object>
                         <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
-                            <property name="proportion">1</property>
-                            <object class="wxTextCtrl" expanded="1">
+                            <property name="flag">wxALIGN_CENTER_VERTICAL</property>
+                            <property name="proportion">0</property>
+                            <object class="wxSpinCtrlDouble" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -1951,6 +1997,7 @@
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>
                                 <property name="default_pane">0</property>
+                                <property name="digits">3</property>
                                 <property name="dock">Dock</property>
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
@@ -1961,13 +2008,16 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
+                                <property name="inc">1</property>
+                                <property name="initial">0</property>
+                                <property name="max">100</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
                                 <property name="maximum_size"></property>
-                                <property name="maxlength">0</property>
+                                <property name="min">0</property>
                                 <property name="min_size"></property>
                                 <property name="minimize_button">0</property>
-                                <property name="minimum_size">64,-1</property>
+                                <property name="minimum_size">-1,-1</property>
                                 <property name="moveable">1</property>
                                 <property name="name">m_PaddingRightCtrl</property>
                                 <property name="pane_border">1</property>
@@ -1979,26 +2029,21 @@
                                 <property name="resize">Resizable</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
-                                <property name="style">wxTE_PROCESS_ENTER</property>
+                                <property name="style">wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</property>
                                 <property name="subclass">; ; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>
-                                <property name="validator_data_type"></property>
-                                <property name="validator_style">wxFILTER_NONE</property>
-                                <property name="validator_type">wxDefaultValidator</property>
-                                <property name="validator_variable"></property>
                                 <property name="value"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
-                                <event name="OnTextEnter">OnOkClick</event>
                             </object>
                         </object>
                         <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
-                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
-                            <property name="proportion">1</property>
-                            <object class="wxTextCtrl" expanded="1">
+                            <property name="flag">wxALIGN_CENTER_VERTICAL</property>
+                            <property name="proportion">0</property>
+                            <object class="wxSpinCtrlDouble" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -2016,6 +2061,7 @@
                                 <property name="context_help"></property>
                                 <property name="context_menu">1</property>
                                 <property name="default_pane">0</property>
+                                <property name="digits">3</property>
                                 <property name="dock">Dock</property>
                                 <property name="dock_fixed">0</property>
                                 <property name="docking">Left</property>
@@ -2026,13 +2072,16 @@
                                 <property name="gripper">0</property>
                                 <property name="hidden">0</property>
                                 <property name="id">wxID_ANY</property>
+                                <property name="inc">1</property>
+                                <property name="initial">0</property>
+                                <property name="max">100</property>
                                 <property name="max_size"></property>
                                 <property name="maximize_button">0</property>
                                 <property name="maximum_size"></property>
-                                <property name="maxlength">0</property>
+                                <property name="min">0</property>
                                 <property name="min_size"></property>
                                 <property name="minimize_button">0</property>
-                                <property name="minimum_size">64,-1</property>
+                                <property name="minimum_size">-1,-1</property>
                                 <property name="moveable">1</property>
                                 <property name="name">m_PaddingBottomCtrl</property>
                                 <property name="pane_border">1</property>
@@ -2044,19 +2093,14 @@
                                 <property name="resize">Resizable</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
-                                <property name="style">wxTE_PROCESS_ENTER</property>
+                                <property name="style">wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER</property>
                                 <property name="subclass">; ; forward_declare</property>
                                 <property name="toolbar_pane">0</property>
                                 <property name="tooltip"></property>
-                                <property name="validator_data_type"></property>
-                                <property name="validator_style">wxFILTER_NONE</property>
-                                <property name="validator_type">wxDefaultValidator</property>
-                                <property name="validator_variable"></property>
                                 <property name="value"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
-                                <event name="OnTextEnter">OnOkClick</event>
                             </object>
                         </object>
                         <object class="sizeritem" expanded="0">
@@ -2118,6 +2162,16 @@
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
                                 <property name="wrap">-1</property>
+                            </object>
+                        </object>
+                        <object class="sizeritem" expanded="1">
+                            <property name="border">5</property>
+                            <property name="flag">wxEXPAND</property>
+                            <property name="proportion">1</property>
+                            <object class="spacer" expanded="1">
+                                <property name="height">0</property>
+                                <property name="permission">protected</property>
+                                <property name="width">0</property>
                             </object>
                         </object>
                     </object>


### PR DESCRIPTION
I found the original scaling mechanism did not provide me accurate label dimensions. With this modification, the user is able to enter their desired label width and height and the plugin will generate a label that corresponds to those dimensions.

I also modified the dialog to use spinCtrls instead of textCtrls for the numeric inputs. These controls are updated within the code to provide the current value. The spin controls allow for easier input when dealing with the updating of the values.

Create a label of a defined size
=========================
![Screenshot_2023-01-02_00-23-44](https://user-images.githubusercontent.com/105990459/210202067-c306c5f8-b5ca-4c91-bd75-fe70d6547bef.png)
Accurate height dimension
======================
![Screenshot_2023-01-02_00-33-13](https://user-images.githubusercontent.com/105990459/210202085-bb228d85-ce1e-4f3a-a933-0dfd22d7c0f2.png)
Accurate width dimension
=====================
![Screenshot_2023-01-02_00-53-40](https://user-images.githubusercontent.com/105990459/210202092-8ec0b096-db22-44fc-8828-c7e029567944.png)
