### PR TITLE
allow opentype files as well

### DIFF
--- a/KiBuzzard/buzzard/buzzard.py
+++ b/KiBuzzard/buzzard/buzzard.py
@@ -46,7 +46,7 @@ class Buzzard():
         for entry in os.listdir(typeface_path):
             entry_path = os.path.join(typeface_path, entry)
             
-            if not entry_path.endswith('.ttf'):
+            if not (entry_path.endswith('.ttf') or entry_path.endswith('.otf')):
                 continue
 
             fnt_lib[os.path.splitext(os.path.basename(entry_path))[0]] = {'Path':entry_path}

--- a/KiBuzzard/dialog/dialog.py
+++ b/KiBuzzard/dialog/dialog.py
@@ -43,7 +43,7 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         for entry in os.listdir(typeface_path):
             entry_path = os.path.join(typeface_path, entry)
             
-            if not entry_path.endswith('.ttf'):
+            if not (entry_path.endswith('.ttf') or entry_path.endswith('.otf')):
                 continue
             
             self.m_FontComboBox.Append(os.path.splitext(entry)[0])


### PR DESCRIPTION
The underlying library handles opentype fonts as well; this permits them to be displayed in the dialog.