### PR TITLE
dialog: Fix scaling issues

### DIFF
--- a/KiBuzzard/dialog/dialog.py
+++ b/KiBuzzard/dialog/dialog.py
@@ -224,13 +224,13 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
 
         #initial render with no caps to determine text-only bounding-box sizing for scaling
         if self.m_MultiLineText.GetValue():
-            self.buzzard.leftCap = 'square'
-            self.buzzard.rightCap = 'square'
+            self.buzzard.leftCap = ''
+            self.buzzard.rightCap = ''
             t=self.buzzard.renderLabel(self.m_MultiLineText.GetValue())
         
             textWidth=round(t.bbox()[1].x-t.bbox()[0].x,3)
             textHeight=round(t.bbox()[1].y-t.bbox()[0].y,3)
-            self.buzzard.scaleFactor=(96/25.4)*((requestedHeight-(self.buzzard.padding.top-self.buzzard.padding.bottom))/textHeight)
+            self.buzzard.scaleFactor=(96/25.4)*(requestedHeight/textHeight)
             rawScaleFactor=(self.buzzard.scaleFactor/(96/25.4))
 
             scaledTextWidth=textWidth*rawScaleFactor            
@@ -249,7 +249,7 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
             labelHeight=round(t.bbox()[1].y-t.bbox()[0].y,3)
             
             scaledLabelWidth=labelWidth*rawScaleFactor
-            scaledLabelHeight=labelHeight*rawScaleFactor
+            scaledLabelHeight=labelHeight
             deltaWidth=scaledLabelWidth-scaledTextWidth
             
             #in order to make our item width match the requested item 
@@ -259,11 +259,6 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
             #if (self.buzzard.leftCap != '') & (self.buzzard.rightCap != ''): #causes an error due to the fact that the bounding box is created 
             if self.m_HeightCtrl.GetValue() < requestedHeight:
                 self.m_HeightCtrl.SetValue(scaledLabelHeight) 
-            #needed for realtime update of size since we can not set the width smaller than the bounding box created
-            #for that particular height of character.
-            #character height drives the scaling factor and thus is applied first
-            if requestedWidth<scaledLabelWidth:
-                self.m_WidthCtrl.SetValue(scaledLabelWidth)
 
             self.error = None
         

--- a/KiBuzzard/dialog/dialog.py
+++ b/KiBuzzard/dialog/dialog.py
@@ -213,10 +213,6 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         for attr in ['left', 'right', 'top', 'bottom']:
             if getattr(self.buzzard.padding,attr) <= 0: setattr(self.buzzard.padding, attr, 0.001) 
  
-        #do the realtime update
-        for attr, ctrl in [('left','m_PaddingLeftCtrl'), ('right','m_PaddingRightCtrl'), ('top','m_PaddingTopCtrl'), ('bottom','m_PaddingBottomCtrl')]:            
-            getattr(self, ctrl).SetValue(getattr(self.buzzard.padding, attr,3))
-  
         self.buzzard.layer = self.m_LayerComboBox.GetValue()
         self.buzzard.width = ParseFloat(self.m_WidthCtrl.GetValue(), 0.0)
 

--- a/KiBuzzard/dialog/dialog.py
+++ b/KiBuzzard/dialog/dialog.py
@@ -222,7 +222,10 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         if self.m_MultiLineText.GetValue():
             self.buzzard.leftCap = ''
             self.buzzard.rightCap = ''
-            t=self.buzzard.renderLabel(self.m_MultiLineText.GetValue())
+            
+            # Calculate text height based off first line
+            text = self.m_MultiLineText.GetValue().split('\n')
+            t=self.buzzard.renderLabel(text[0])
         
             textWidth=round(t.bbox()[1].x-t.bbox()[0].x,3)
             textHeight=round(t.bbox()[1].y-t.bbox()[0].y,3)

--- a/KiBuzzard/dialog/dialog_text_base.py
+++ b/KiBuzzard/dialog/dialog_text_base.py
@@ -116,8 +116,8 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         fgSizerSetup.Add( self.m_HeightLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT|wx.LEFT, 5 )
 
-        self.m_HeightCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 128, 0, 0.25 )
-        self.m_HeightCtrl.SetDigits( 3 )
+        self.m_HeightCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 128, 0, 0.1 )
+        self.m_HeightCtrl.SetDigits( 1 )
         fgSizerSetup.Add( self.m_HeightCtrl, 0, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
 
         self.m_HeightUnits = wx.StaticText( self, wx.ID_ANY, _(u"unit"), wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -140,8 +140,8 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         fgSizerSetup.Add( self.m_WidthLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.LEFT|wx.RIGHT, 5 )
 
-        self.m_WidthCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 128, 0, 0.25 )
-        self.m_WidthCtrl.SetDigits( 3 )
+        self.m_WidthCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 128, 0, 0.1 )
+        self.m_WidthCtrl.SetDigits( 1 )
         fgSizerSetup.Add( self.m_WidthCtrl, 0, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
 
         self.m_WidthUnits = wx.StaticText( self, wx.ID_ANY, _(u"unit"), wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -235,19 +235,19 @@ class DIALOG_TEXT_BASE ( DialogShim ):
         fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
         self.m_PaddingTopCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
-        self.m_PaddingTopCtrl.SetDigits( 3 )
+        self.m_PaddingTopCtrl.SetDigits( 1 )
         fgSizerPadding.Add( self.m_PaddingTopCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
         self.m_PaddingLeftCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
-        self.m_PaddingLeftCtrl.SetDigits( 3 )
+        self.m_PaddingLeftCtrl.SetDigits( 1 )
         fgSizerPadding.Add( self.m_PaddingLeftCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
         self.m_PaddingRightCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
-        self.m_PaddingRightCtrl.SetDigits( 3 )
+        self.m_PaddingRightCtrl.SetDigits( 1 )
         fgSizerPadding.Add( self.m_PaddingRightCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
         self.m_PaddingBottomCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
-        self.m_PaddingBottomCtrl.SetDigits( 3 )
+        self.m_PaddingBottomCtrl.SetDigits( 1 )
         fgSizerPadding.Add( self.m_PaddingBottomCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
 

--- a/KiBuzzard/dialog/dialog_text_base.py
+++ b/KiBuzzard/dialog/dialog_text_base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ###########################################################################
-## Python code generated with wxFormBuilder (version 4.0.0-0-g0efcecf)
+## Python code generated with wxFormBuilder (version 4.1.0-0-g733bf3d)
 ## http://www.wxformbuilder.org/
 ##
 ## PLEASE DO *NOT* EDIT THIS FILE!
@@ -186,11 +186,11 @@ class DIALOG_TEXT_BASE ( DialogShim ):
         self.m_staticline1 = wx.StaticLine( self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL )
         bMainSizer.Add( self.m_staticline1, 0, wx.BOTTOM|wx.EXPAND|wx.LEFT|wx.RIGHT, 5 )
 
-        fgSizerPadding = wx.FlexGridSizer( 0, 5, 4, 4 )
+        fgSizerPadding = wx.FlexGridSizer( 0, 8, 4, 4 )
         fgSizerPadding.AddGrowableCol( 1 )
-        fgSizerPadding.AddGrowableCol( 2 )
         fgSizerPadding.AddGrowableCol( 3 )
-        fgSizerPadding.AddGrowableCol( 4 )
+        fgSizerPadding.AddGrowableCol( 5 )
+        fgSizerPadding.AddGrowableCol( 7 )
         fgSizerPadding.SetFlexibleDirection( wx.BOTH )
         fgSizerPadding.SetNonFlexibleGrowMode( wx.FLEX_GROWMODE_SPECIFIED )
 
@@ -211,20 +211,38 @@ class DIALOG_TEXT_BASE ( DialogShim ):
 
         fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
         self.m_PaddingTopLabel = wx.StaticText( self, wx.ID_ANY, _(u"Top"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_PaddingTopLabel.Wrap( -1 )
 
         fgSizerPadding.Add( self.m_PaddingTopLabel, 1, wx.ALIGN_CENTER, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
         self.m_PaddingLeftLabel = wx.StaticText( self, wx.ID_ANY, _(u"Left"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_PaddingLeftLabel.Wrap( -1 )
 
         fgSizerPadding.Add( self.m_PaddingLeftLabel, 1, wx.ALIGN_CENTER, 5 )
 
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
         self.m_PaddingRightLabel = wx.StaticText( self, wx.ID_ANY, _(u"Right"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_PaddingRightLabel.Wrap( -1 )
 
         fgSizerPadding.Add( self.m_PaddingRightLabel, 1, wx.ALIGN_CENTER, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
         self.m_PaddingBottomLabel = wx.StaticText( self, wx.ID_ANY, _(u"Bottom"), wx.DefaultPosition, wx.DefaultSize, 0 )
         self.m_PaddingBottomLabel.Wrap( -1 )
@@ -238,13 +256,22 @@ class DIALOG_TEXT_BASE ( DialogShim ):
         self.m_PaddingTopCtrl.SetDigits( 1 )
         fgSizerPadding.Add( self.m_PaddingTopCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
         self.m_PaddingLeftCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
         self.m_PaddingLeftCtrl.SetDigits( 1 )
         fgSizerPadding.Add( self.m_PaddingLeftCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
 
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
+
         self.m_PaddingRightCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
         self.m_PaddingRightCtrl.SetDigits( 1 )
         fgSizerPadding.Add( self.m_PaddingRightCtrl, 0, wx.ALIGN_CENTER_VERTICAL, 5 )
+
+
+        fgSizerPadding.Add( ( 0, 0), 1, wx.EXPAND, 5 )
 
         self.m_PaddingBottomCtrl = wx.SpinCtrlDouble( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS|wx.TE_PROCESS_ENTER, 0, 100, 0, 1 )
         self.m_PaddingBottomCtrl.SetDigits( 1 )

--- a/text_dialog.fbp
+++ b/text_dialog.fbp
@@ -58,16 +58,16 @@
       <property name="window_name"></property>
       <property name="window_style"></property>
       <event name="OnInitDialog">OnInitDlg</event>
-      <object class="wxBoxSizer" expanded="true">
+      <object class="wxBoxSizer" expanded="false">
         <property name="minimum_size"></property>
         <property name="name">bMainSizer</property>
         <property name="orient">wxVERTICAL</property>
         <property name="permission">none</property>
-        <object class="sizeritem" expanded="true">
+        <object class="sizeritem" expanded="false">
           <property name="border">10</property>
           <property name="flag">wxEXPAND|wxALL</property>
           <property name="proportion">20</property>
-          <object class="wxBoxSizer" expanded="true">
+          <object class="wxBoxSizer" expanded="false">
             <property name="minimum_size">-1,-1</property>
             <property name="name">m_MultiLineSizer</property>
             <property name="orient">wxVERTICAL</property>
@@ -205,20 +205,20 @@
             </object>
           </object>
         </object>
-        <object class="sizeritem" expanded="true">
+        <object class="sizeritem" expanded="false">
           <property name="border">10</property>
           <property name="flag">wxEXPAND|wxBOTTOM|wxRIGHT|wxLEFT</property>
           <property name="proportion">20</property>
-          <object class="wxBoxSizer" expanded="true">
+          <object class="wxBoxSizer" expanded="false">
             <property name="minimum_size"></property>
             <property name="name">m_SingleLineSizer</property>
             <property name="orient">wxVERTICAL</property>
             <property name="permission">protected</property>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxLEFT|wxRIGHT</property>
               <property name="proportion">0</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -276,11 +276,11 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALL|wxEXPAND</property>
               <property name="proportion">1</property>
-              <object class="wxPanel" expanded="true">
+              <object class="wxPanel" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -336,11 +336,11 @@
             </object>
           </object>
         </object>
-        <object class="sizeritem" expanded="true">
+        <object class="sizeritem" expanded="false">
           <property name="border">10</property>
           <property name="flag">wxEXPAND|wxRIGHT|wxLEFT</property>
           <property name="proportion">0</property>
-          <object class="wxFlexGridSizer" expanded="true">
+          <object class="wxFlexGridSizer" expanded="false">
             <property name="cols">5</property>
             <property name="flexible_direction">wxBOTH</property>
             <property name="growablecols">1,4</property>
@@ -414,11 +414,11 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
               <property name="proportion">2</property>
-              <object class="wxComboBox" expanded="true">
+              <object class="wxComboBox" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -490,11 +490,11 @@
                 <property name="width">0</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT</property>
               <property name="proportion">0</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -552,11 +552,11 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">3</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND|wxRIGHT</property>
               <property name="proportion">1</property>
-              <object class="wxChoice" expanded="true">
+              <object class="wxChoice" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -679,11 +679,11 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
               <property name="proportion">0</property>
-              <object class="wxSpinCtrlDouble" expanded="true">
+              <object class="wxSpinCtrlDouble" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -933,11 +933,11 @@
                 <property name="window_style"></property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT</property>
               <property name="proportion">0</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -995,11 +995,11 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND</property>
               <property name="proportion">0</property>
-              <object class="wxSpinCtrlDouble" expanded="true">
+              <object class="wxSpinCtrlDouble" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1060,11 +1060,11 @@
                 <property name="window_style"></property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT</property>
               <property name="proportion">0</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1122,11 +1122,11 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT</property>
               <property name="proportion">0</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1184,11 +1184,11 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">3</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL|wxEXPAND|wxRIGHT</property>
               <property name="proportion">0</property>
-              <object class="wxChoice" expanded="true">
+              <object class="wxChoice" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1249,21 +1249,21 @@
                 <property name="window_style"></property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxEXPAND</property>
               <property name="proportion">0</property>
-              <object class="spacer" expanded="true">
+              <object class="spacer" expanded="false">
                 <property name="height">0</property>
                 <property name="permission">protected</property>
                 <property name="width">0</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxEXPAND</property>
               <property name="proportion">1</property>
-              <object class="spacer" expanded="true">
+              <object class="spacer" expanded="false">
                 <property name="height">0</property>
                 <property name="permission">protected</property>
                 <property name="width">0</property>
@@ -1419,11 +1419,11 @@
             <property name="width">0</property>
           </object>
         </object>
-        <object class="sizeritem" expanded="true">
+        <object class="sizeritem" expanded="false">
           <property name="border">5</property>
           <property name="flag">wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT</property>
           <property name="proportion">0</property>
-          <object class="wxStaticLine" expanded="true">
+          <object class="wxStaticLine" expanded="false">
             <property name="BottomDockable">1</property>
             <property name="LeftDockable">1</property>
             <property name="RightDockable">1</property>
@@ -1478,14 +1478,14 @@
             <property name="window_style"></property>
           </object>
         </object>
-        <object class="sizeritem" expanded="true">
+        <object class="sizeritem" expanded="false">
           <property name="border">10</property>
-          <property name="flag">wxEXPAND|wxLEFT|wxRIGHT</property>
+          <property name="flag">wxEXPAND|wxLEFT|wxRESERVE_SPACE_EVEN_IF_HIDDEN|wxRIGHT</property>
           <property name="proportion">0</property>
-          <object class="wxFlexGridSizer" expanded="true">
-            <property name="cols">5</property>
+          <object class="wxFlexGridSizer" expanded="false">
+            <property name="cols">8</property>
             <property name="flexible_direction">wxBOTH</property>
-            <property name="growablecols">1,2,3,4</property>
+            <property name="growablecols">1,3,5,7</property>
             <property name="growablerows"></property>
             <property name="hgap">4</property>
             <property name="minimum_size"></property>
@@ -1556,11 +1556,31 @@
                 <property name="wrap">-1</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxEXPAND</property>
               <property name="proportion">1</property>
-              <object class="spacer" expanded="true">
+              <object class="spacer" expanded="false">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="false">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="false">
                 <property name="height">0</property>
                 <property name="permission">protected</property>
                 <property name="width">0</property>
@@ -1597,10 +1617,20 @@
               </object>
             </object>
             <object class="sizeritem" expanded="true">
+              <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="true">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER</property>
               <property name="proportion">1</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1660,9 +1690,19 @@
             </object>
             <object class="sizeritem" expanded="true">
               <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="true">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER</property>
               <property name="proportion">1</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1722,9 +1762,19 @@
             </object>
             <object class="sizeritem" expanded="true">
               <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="true">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER</property>
               <property name="proportion">1</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1784,9 +1834,19 @@
             </object>
             <object class="sizeritem" expanded="true">
               <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="true">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER</property>
               <property name="proportion">1</property>
-              <object class="wxStaticText" expanded="true">
+              <object class="wxStaticText" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1854,11 +1914,11 @@
                 <property name="width">0</property>
               </object>
             </object>
-            <object class="sizeritem" expanded="true">
+            <object class="sizeritem" expanded="false">
               <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL</property>
               <property name="proportion">0</property>
-              <object class="wxSpinCtrlDouble" expanded="true">
+              <object class="wxSpinCtrlDouble" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1921,9 +1981,19 @@
             </object>
             <object class="sizeritem" expanded="true">
               <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="true">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL</property>
               <property name="proportion">0</property>
-              <object class="wxSpinCtrlDouble" expanded="true">
+              <object class="wxSpinCtrlDouble" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -1986,9 +2056,19 @@
             </object>
             <object class="sizeritem" expanded="true">
               <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="true">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL</property>
               <property name="proportion">0</property>
-              <object class="wxSpinCtrlDouble" expanded="true">
+              <object class="wxSpinCtrlDouble" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -2051,9 +2131,19 @@
             </object>
             <object class="sizeritem" expanded="true">
               <property name="border">5</property>
+              <property name="flag">wxEXPAND</property>
+              <property name="proportion">1</property>
+              <object class="spacer" expanded="true">
+                <property name="height">0</property>
+                <property name="permission">protected</property>
+                <property name="width">0</property>
+              </object>
+            </object>
+            <object class="sizeritem" expanded="false">
+              <property name="border">5</property>
               <property name="flag">wxALIGN_CENTER_VERTICAL</property>
               <property name="proportion">0</property>
-              <object class="wxSpinCtrlDouble" expanded="true">
+              <object class="wxSpinCtrlDouble" expanded="false">
                 <property name="BottomDockable">1</property>
                 <property name="LeftDockable">1</property>
                 <property name="RightDockable">1</property>
@@ -2175,11 +2265,11 @@
             <property name="window_style"></property>
           </object>
         </object>
-        <object class="sizeritem" expanded="true">
+        <object class="sizeritem" expanded="false">
           <property name="border">5</property>
           <property name="flag">wxEXPAND</property>
           <property name="proportion">0</property>
-          <object class="wxBoxSizer" expanded="true">
+          <object class="wxBoxSizer" expanded="false">
             <property name="minimum_size"></property>
             <property name="name">lowerSizer</property>
             <property name="orient">wxHORIZONTAL</property>

--- a/text_dialog.fbp
+++ b/text_dialog.fbp
@@ -701,7 +701,7 @@
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
                 <property name="default_pane">0</property>
-                <property name="digits">3</property>
+                <property name="digits">1</property>
                 <property name="dock">Dock</property>
                 <property name="dock_fixed">0</property>
                 <property name="docking">Left</property>
@@ -713,7 +713,7 @@
                 <property name="gripper">0</property>
                 <property name="hidden">0</property>
                 <property name="id">wxID_ANY</property>
-                <property name="inc">0.25</property>
+                <property name="inc">0.1</property>
                 <property name="initial">0</property>
                 <property name="max">128</property>
                 <property name="max_size"></property>
@@ -1017,7 +1017,7 @@
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
                 <property name="default_pane">0</property>
-                <property name="digits">3</property>
+                <property name="digits">1</property>
                 <property name="dock">Dock</property>
                 <property name="dock_fixed">0</property>
                 <property name="docking">Left</property>
@@ -1029,7 +1029,7 @@
                 <property name="gripper">0</property>
                 <property name="hidden">0</property>
                 <property name="id">wxID_ANY</property>
-                <property name="inc">0.25</property>
+                <property name="inc">0.1</property>
                 <property name="initial">0</property>
                 <property name="max">128</property>
                 <property name="max_size"></property>
@@ -1876,7 +1876,7 @@
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
                 <property name="default_pane">0</property>
-                <property name="digits">3</property>
+                <property name="digits">1</property>
                 <property name="dock">Dock</property>
                 <property name="dock_fixed">0</property>
                 <property name="docking">Left</property>
@@ -1941,7 +1941,7 @@
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
                 <property name="default_pane">0</property>
-                <property name="digits">3</property>
+                <property name="digits">1</property>
                 <property name="dock">Dock</property>
                 <property name="dock_fixed">0</property>
                 <property name="docking">Left</property>
@@ -2006,7 +2006,7 @@
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
                 <property name="default_pane">0</property>
-                <property name="digits">3</property>
+                <property name="digits">1</property>
                 <property name="dock">Dock</property>
                 <property name="dock_fixed">0</property>
                 <property name="docking">Left</property>
@@ -2071,7 +2071,7 @@
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
                 <property name="default_pane">0</property>
-                <property name="digits">3</property>
+                <property name="digits">1</property>
                 <property name="dock">Dock</property>
                 <property name="dock_fixed">0</property>
                 <property name="docking">Left</property>


### PR DESCRIPTION
 - Decouple top/bottom padding from text height, this makes the text height match between capped and uncapped labels.
 - Remove width override when label becomes longer than requested.

This returns some behaviour to normal, but keeps the accurate scaling of width and height.

[Screencast from 2024-02-26 21-24-57.webm](https://github.com/gregdavill/KiBuzzard/assets/344310/3007bca6-c901-4ebb-bb90-374608237dcb)
