### PR TITLE
dialog: Fix text height

### DIFF
--- a/KiBuzzard/buzzard/buzzard.py
+++ b/KiBuzzard/buzzard/buzzard.py
@@ -71,6 +71,19 @@ class Buzzard():
 
         return mod.polys
 
+    def text_height(self, char_used_for_height='H'):
+        # t is an svg Text element
+        t = svg.Text()
+
+        t.set_font(self.fontName)
+        t.add_text(char_used_for_height)
+        
+        # This needs to be called to convert raw text to useable path elements
+        t.convert_to_path()
+
+        bbox = t.bbox()
+        return bbox[1].y - bbox[0].y
+
     # ******************************************************************************
     #
     # Create SVG Document containing properly formatted inString

--- a/KiBuzzard/deps/svg2mod/svg2mod/svg/svg.py
+++ b/KiBuzzard/deps/svg2mod/svg2mod/svg/svg.py
@@ -1339,7 +1339,7 @@ class Text(Transformable):
             size = attrib.size
             ttf = ttFont.TTFont(attrib.font_file)
             offset.y = attrib.origin.y + ttf["head"].unitsPerEm
-            scale = size/offset.y
+            scale = size/ttf["head"].unitsPerEm
 
             if prev_origin != attrib.origin:
                 prev_origin = attrib.origin
@@ -1365,7 +1365,7 @@ class Text(Transformable):
                     path.append(Path())
                     path[-1].parse(path_buff)
                     # Apply the scaling then the translation
-                    translate = Matrix([1,0,0,-1,offset.x,size+attrib.origin.y]) * Matrix([scale,0,0,scale,0,0])
+                    translate = Matrix([1,0,0,-1,offset.x,attrib.origin.y]) * Matrix([scale,0,0,scale,0,0])
                     # This queues the translations until .transform() is called
                     path[-1].matrix =  translate * path[-1].matrix
 


### PR DESCRIPTION
I've had issues with the current text height scaling.

The current method renders the label and captures the height, this height is then scaled compared to the requested height.
This results in the following strings being rendered at the same height: `test`, `TEST`, `a`, `_a`, `_b`, `_.`

![Screenshot from 2024-03-02 21-03-57](https://github.com/gregdavill/KiBuzzard/assets/344310/bf510949-3b1b-488f-80f7-2c3631117339)

If we instead use a fixed value, the resulting height is not exactly matching the value entered, but ensures that labels with different height characters end up with matching sizes.