### PR TITLE
use language independant code to find pcbnew frame

### DIFF
--- a/KiBuzzard/plugin.py
+++ b/KiBuzzard/plugin.py
@@ -45,7 +45,7 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
     def Run(self):
         if self._pcbnew_frame is None:
             try:
-                self._pcbnew_frame = [x for x in wx.GetTopLevelWindows() if ('pcbnew' in x.GetTitle().lower() and not 'python' in x.GetTitle().lower()) or ('pcb editor' in x.GetTitle().lower())]
+                self._pcbnew_frame = [x for x in wx.GetTopLevelWindows() if (wx.GetTranslation('pcbnew') in x.GetTitle() and not 'python' in x.GetTitle().lower()) or (wx.GetTranslation('PCB Editor') in x.GetTitle())]
                 if len(self._pcbnew_frame) == 1:
                     self._pcbnew_frame = self._pcbnew_frame[0]
                 else:


### PR DESCRIPTION
On Ubuntu using KiCad version 8.0.1 I can't use the plugin if the language is set to German even with the branch v8 because the pcbnew windows name is different.  
That's why the plugin can't find the pcbnew window. The problem occurs when pressing the OK button.  
With this fix it works as expected.  
```
04-10 10:20:25 com_github_gregdavill_KiBuzzard.plugin 150:No pcbnew window found
```
Using the wxWidgets translation functions fixes the problem.

---  
English  
![image](https://github.com/gregdavill/KiBuzzard/assets/945075/b5ebf9e6-c8ce-47be-a407-861dc0d7190c)  
---  
German  
![image](https://github.com/gregdavill/KiBuzzard/assets/945075/e5372a68-6021-4234-b581-1ffc07471b86)  

```
Application: KiCad PCB Editor x86_64 on x86_64

Version: 8.0.1-8.0.1-1~ubuntu22.04.1, release build

Libraries:
	wxWidgets 3.2.1
	FreeType 2.11.1
	HarfBuzz 2.7.4
	FontConfig 2.13.1
	libcurl/7.81.0 OpenSSL/3.0.2 zlib/1.2.11 brotli/1.0.9 zstd/1.4.8 libidn2/2.3.2 libpsl/0.21.0 (+libidn2/2.3.2) libssh/0.9.6/openssl/zlib nghttp2/1.43.0 librtmp/2.3 OpenLDAP/2.5.17

Platform: Ubuntu 22.04.4 LTS, 64 bit, Little endian, wxGTK, X11, cinnamon, x11

Build Info:
	Date: Mar 14 2024 17:17:31
	wxWidgets: 3.2.1 (wchar_t,wx containers) GTK+ 3.24
	Boost: 1.74.0
	OCC: 7.6.3
	Curl: 7.81.0
	ngspice: 42
	Compiler: GCC 11.4.0 with C++ ABI 1016

Build settings:
```

