### PR TITLE
feat: add back copper layer (B.Cu) support with automatic text mirroring

### DIFF
--- a/KiBuzzard/buzzard/buzzard.py
+++ b/KiBuzzard/buzzard/buzzard.py
@@ -169,14 +169,24 @@ class Buzzard():
 
     def create_v6_footprint(self, parm_text=None):
         name = "kibuzzard-{:8X}".format(int(round(time.time())))
-        mod = Svg2ModExportLatestCustom(Svg2ModImport(module_name=name, module_value="G***"), precision=1.0, scale_factor=self.scaleFactor, center=True, params=parm_text)
-        if self.layer == "F.Cu/F.Mask":
-            mod.add_svg_element(self.svgText, layer="F.Cu")
+        on_back = self.layer.startswith("B.")
+        fp_layer = "B.Cu" if on_back else "F.Cu"
+        mod = Svg2ModExportLatestCustom(
+            Svg2ModImport(module_name=name, module_value="G***"),
+            precision=1.0, scale_factor=self.scaleFactor, center=True,
+            params=parm_text, layer=fp_layer,
+        )
+
+        if self.layer in ("F.Cu/F.Mask", "B.Cu/B.Mask"):
+            cu_layer  = "B.Cu"  if on_back else "F.Cu"
+            msk_layer = "B.Mask" if on_back else "F.Mask"
+            mod.add_svg_element(self.svgText, layer=cu_layer)
             offset_text = copy.copy(self.svgText)
             offset_text.style["stroke-width"] = 0.2
-            mod.add_svg_element(offset_text, layer="F.Mask")
+            mod.add_svg_element(offset_text, layer=msk_layer)
         else:
             mod.add_svg_element(self.svgText, layer=self.layer)
+
         mod.write()
         return mod.raw_file_data
     
@@ -313,7 +323,7 @@ class Buzzard():
         return bbox[1].x - bbox[0].x            
 
 class Svg2ModExportLatestCustom( Svg2ModExportLatest ):
-    
+
     def __init__(
         self,
         svg2mod_import = Svg2ModImport(),
@@ -323,9 +333,11 @@ class Svg2ModExportLatestCustom( Svg2ModExportLatest ):
         precision = 1.0,
         use_mm = True,
         dpi = DEFAULT_DPI,
-        params = None
+        params = None,
+        layer = "F.Cu",
     ):
         self.params = params
+        self.fp_layer = layer
         super( Svg2ModExportLatestCustom, self ).__init__(
             svg2mod_import,
             file_name,
@@ -339,7 +351,7 @@ class Svg2ModExportLatestCustom( Svg2ModExportLatest ):
 
 
     def _write_library_intro( self, cmdline ):
-        self.output_file.write( """(footprint {0} (layer F.Cu) (tedit {1:8X}) (generator kibuzzard)
+        self.output_file.write( """(footprint {0} (layer {4}) (tedit {1:8X}) (generator kibuzzard)
     (attr board_only exclude_from_pos_files exclude_from_bom)
     (descr "{2}")
     (tags "kb_params={3}")
@@ -350,9 +362,23 @@ class Svg2ModExportLatestCustom( Svg2ModExportLatest ):
                 ) ),
                 "Generated with KiBuzzard", #2
                 self.params, #3
+                self.fp_layer, #4
             )
         )
     
+    def _write_modules(self):
+        # For back-side layers svg2mod's flip mechanism negates X coordinates,
+        # which is exactly what we need for readable text on B.Cu.
+        front = not self.fp_layer.startswith("B.")
+        self._write_module(front=front)
+
+    def _write_polygon_point(self, point):
+        if self._extra_indent:
+            self.output_file.write("  " * self._extra_indent)
+        self.output_file.write(
+            "      (xy {:.6g} {:.6g})\n".format(point.x, point.y)
+        )
+
     def _write_module_header(
         self, label_size, label_pen,
         reference_y, value_y, front,

--- a/KiBuzzard/dialog/dialog.py
+++ b/KiBuzzard/dialog/dialog.py
@@ -67,7 +67,10 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
         #for fnt in buzzard.SystemFonts:
         #    self.m_FontComboBox.Append(fnt)
 
-        self._layer_choices = layer_choices = ["F.Cu", "F.Paste", "F.SilkS", "F.Mask", "F.Cu/F.Mask"]
+        self._layer_choices = layer_choices = [
+            "F.Cu", "F.Paste", "F.SilkS", "F.Mask", "F.Cu/F.Mask",
+            "B.Cu", "B.Paste", "B.SilkS", "B.Mask", "B.Cu/B.Mask",
+        ]
         self.m_LayerComboBox.AppendItems(layer_choices)
         self.m_LayerComboBox.SetSelection(0)
         self.m_HeightUnits.SetLabel("mm")
@@ -132,9 +135,22 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
                         encoded_str = param_str[10:]
                         json_str = base64.b64decode(encoded_str).decode('utf-8')
                         params = json.loads(json_str)
-                        self.LoadSettings(params)
                         self.updateFootprint = f
 
+                        # Migrate old footprints: if the footprint lives on B.Cu
+                        # but was saved with an F.* layer (pre-back-layer support),
+                        # flip the layer choice so the dialog reflects reality.
+                        _layer_migration = {
+                            'F.Cu': 'B.Cu', 'F.Paste': 'B.Paste',
+                            'F.SilkS': 'B.SilkS', 'F.Mask': 'B.Mask',
+                            'F.Cu/F.Mask': 'B.Cu/B.Mask',
+                        }
+                        if f.GetLayer() == pcbnew.B_Cu:
+                            stored = params.get('LayerComboBox', 'F.Cu')
+                            if not stored.startswith('B.'):
+                                params['LayerComboBox'] = _layer_migration.get(stored, 'B.Cu')
+
+                        self.LoadSettings(params)
                         return
                 
         except Exception:
@@ -338,10 +354,11 @@ class Dialog(dialog_text_base.DIALOG_TEXT_BASE):
                 scale = (size_x * 0.95) / width
                 scale = min(scale, (size_y * 0.95) / height)
 
-                #scale = min(15.0, scale)
+                mirror = self.buzzard.layer.startswith("B.")
                 for i in range(len(polys)):
                     for j in range(len(polys[i])):
-                        polys[i][j] = (scale*polys[i][j].x,scale*polys[i][j].y)
+                        x = -polys[i][j].x if mirror else polys[i][j].x
+                        polys[i][j] = (scale * x, scale * polys[i][j].y)
 
                 dc.DrawPolygonList(polys)
 

--- a/KiBuzzard/dialog/dialog_text_base.py
+++ b/KiBuzzard/dialog/dialog_text_base.py
@@ -177,7 +177,7 @@ class DIALOG_TEXT_BASE ( DialogShim ):
         fgSizerSetup.Add( self.m_LayerComboBox1, 0, wx.ALIGN_CENTER_VERTICAL|wx.LEFT|wx.RIGHT, 5 )
 
         m_LayerComboBoxChoices = []
-        self.m_LayerComboBox = wx.ComboBox( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, m_LayerComboBoxChoices, 0 )
+        self.m_LayerComboBox = wx.ComboBox( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, m_LayerComboBoxChoices, wx.CB_READONLY )
         fgSizerSetup.Add( self.m_LayerComboBox, 0, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5 )
 
 

--- a/KiBuzzard/plugin.py
+++ b/KiBuzzard/plugin.py
@@ -87,21 +87,27 @@ class KiBuzzardPlugin(pcbnew.ActionPlugin, object):
                         pos = dlg.updateFootprint.GetPosition()
                         orient = dlg.updateFootprint.GetOrientationDegrees()
                         wasOnBackLayer = dlg.updateFootprint.GetLayer() == pcbnew.B_Cu
+                        newLayerIsBack = dlg.buzzard.layer.startswith("B.")
 
                         self.logger.log(logging.DEBUG, " pos: {}".format(pos))
                         self.logger.log(logging.DEBUG, " orient: {}".format(orient))
-                        self.logger.log(logging.DEBUG, " need_flip: {}".format(wasOnBackLayer))
-                        
+                        self.logger.log(logging.DEBUG, " wasOnBackLayer: {}".format(wasOnBackLayer))
+                        self.logger.log(logging.DEBUG, " newLayerIsBack: {}".format(newLayerIsBack))
+
                         try:
                             io = pcbnew.PCB_PLUGIN()
                         except AttributeError:
                             io = pcbnew.PCB_IO_KICAD_SEXPR()
-                        
+
                         new_fp = pcbnew.Cast_to_FOOTPRINT(io.Parse(footprint_string))
                         b.Add(new_fp)
                         new_fp.SetPosition(pos)
-                        # Flip before setting orientation
-                        if wasOnBackLayer:
+                        # Flip before setting orientation only when the old footprint was
+                        # on the back and the new one is not (backwards-compat: old footprints
+                        # stored F.Cu params even when they lived on B.Cu).
+                        # When the new layer is already B.*, the footprint string was generated
+                        # with mirrored geometry and B.Cu in its header — no flip needed.
+                        if wasOnBackLayer and not newLayerIsBack:
                             new_fp.Flip(pos, True)
                         new_fp.SetOrientationDegrees(orient)
 


### PR DESCRIPTION
## What this does

Adds support for placing KiBuzzard labels on the back side of the PCB.

## Changes

- **Layer dropdown** now includes `B.Cu`, `B.Paste`, `B.SilkS`, `B.Mask`, `B.Cu/B.Mask`
- **Automatic mirroring**: text geometry is X-flipped for B.* layers using svg2mod's built-in `flip` mechanism (`front=False` in `_write_modules`). The footprint header is also set to `(layer B.Cu)`.
- **Live preview** reflects the mirroring in real time
- **Auto-migration**: old footprints that live on B.Cu but were saved with F.* layer params (pre-this-PR) are automatically corrected when reopened for editing
- **Layer dropdown is now read-only** (`wx.CB_READONLY`) — it was accidentally editable
- **Coordinate precision**: coordinates are now written with 6 significant figures (`:.6g`) instead of raw Python float representation (e.g. `9.906` instead of `9.905999999999997`)

## How the mirroring works

svg2mod's `Svg2ModExport._write_module(front)` already has a flip mechanism: when `front=False`, every X coordinate is negated via `transform_point(..., flip=True)`. `Svg2ModExportLatestCustom` now overrides `_write_modules()` to call `_write_module(front=False)` for B.* layers, which gives correct mirroring without any manual coordinate manipulation.

## Testing

- Generated F.Cu and B.Cu footprints for the same text and verified every X coordinate is exactly negated (0 mismatches on 90 points)
- Verified `(layer B.Cu)` appears in the footprint header for back layers
- Verified the layer dropdown no longer accepts free text input