### PR TITLE
Added 'allow_missing_courtyard' to pass all DRC checks

### DIFF
--- a/KiBuzzard/buzzard/buzzard.py
+++ b/KiBuzzard/buzzard/buzzard.py
@@ -340,7 +340,7 @@ class Svg2ModExportLatestCustom( Svg2ModExportLatest ):
 
     def _write_library_intro( self, cmdline ):
         self.output_file.write( """(footprint {0} (layer F.Cu) (tedit {1:8X}) (generator kibuzzard)
-    (attr board_only exclude_from_pos_files exclude_from_bom)
+    (attr board_only exclude_from_pos_files exclude_from_bom allow_missing_courtyard)
     (descr "{2}")
     (tags "kb_params={3}")
     """.format(


### PR DESCRIPTION
KiBuzzard footprints have no courtyard. And they need no as other DRCs will avoid collisions.
This solves #117 and my bug I hasn't filed yet 🙂
(BTW Thanks for maintaining KiBuzzard)